### PR TITLE
Update 4 Apple + Speak every Dialog

### DIFF
--- a/SpeechMod/Patches/LocalizedString_Patch.cs
+++ b/SpeechMod/Patches/LocalizedString_Patch.cs
@@ -1,0 +1,42 @@
+using System;
+using HarmonyLib;
+using Kingmaker;
+using Kingmaker.GameModes;
+using Kingmaker.Localization;
+using UnityEngine;
+
+namespace SpeechMod.Patches
+{
+	[HarmonyPatch(typeof(LocalizedString), "PlayVoiceOver")]
+	public class LocalizedString_Patch
+	{
+		private static void Prefix(MonoBehaviour target, LocalizedString __instance, VoiceOverStatus __result)
+		{
+      // skip if dialog / book
+			if (Game.Instance.IsModeActive(GameModeType.Dialog))
+			{
+				return;
+			}
+			if (!Main.Enabled)
+			{
+				return;
+			}
+			if (!Main.Settings.AutoPlay)
+			{
+				return;
+			}
+      // only play if no voiceover part1
+			if (__result != null)
+			{
+				return;
+			}
+      // only play if no voiceover part2
+			if (target == null)
+			{
+				return;
+			}
+			Game instance = Game.Instance;
+			Main.Speech.Speak(__instance, 0.5f);
+		}
+	}
+}

--- a/SpeechMod/Unity/AppleVoiceUnity.cs
+++ b/SpeechMod/Unity/AppleVoiceUnity.cs
@@ -31,22 +31,22 @@ public class AppleVoiceUnity : MonoBehaviour
     {
         if (!AppleVoiceUnity.IsVoiceInitialized())
 	    {
-		    return;
+	    	return;
 	    }
 	    if (delay > 0f)
 	    {
-		    AppleVoiceUnity.m_TheVoice.ExecuteLater(delay, delegate
-		    {
-			    AppleVoiceUnity.Speak(text, 0f);
-		    });
-		return;
+	       AppleVoiceUnity.m_TheVoice.ExecuteLater(delay, delegate
+	       {
+	          AppleVoiceUnity.Speak(text, 0f);
+	       });
+	    return;
 	    }
 	    AppleVoiceUnity.Stop();
 	    text = string.Format("-v {0} -r {1} {2};", new object[]
 	    {
-		    Main.NarratorVoice,
-		    Main.Settings.NarratorRate,
-		    text.Replace("\"", "")
+		Main.NarratorVoice,
+		Main.Settings.NarratorRate,
+		text.Replace("\"", "")
 	    });
 	    Process.Start("/usr/bin/say", text);
         }

--- a/SpeechMod/Unity/AppleVoiceUnity.cs
+++ b/SpeechMod/Unity/AppleVoiceUnity.cs
@@ -101,6 +101,7 @@ public class AppleVoiceUnity : MonoBehaviour
 
     private static void KillAll()
     {
-        Process.Start("/usr/bin/killall", "say -kill").WaitForExit();
+        Process.Start("/usr/bin/killall", "bash -kill").WaitForExit();
+	Process.Start("/usr/bin/killall", "say -kill").WaitForExit();
     }
 }

--- a/SpeechMod/Unity/AppleVoiceUnity.cs
+++ b/SpeechMod/Unity/AppleVoiceUnity.cs
@@ -33,19 +33,27 @@ public class AppleVoiceUnity : MonoBehaviour
 
     public static void Speak(string text, float delay = 0f)
     {
-        if (!IsVoiceInitialized())
-            return;
-
-        if (delay > 0f)
-        {
-            m_TheVoice.ExecuteLater(delay, () => Speak(text));
-            return;
+        if (!AppleVoiceUnity.IsVoiceInitialized())
+	    {
+		    return;
+	    }
+	    if (delay > 0f)
+	    {
+		    AppleVoiceUnity.m_TheVoice.ExecuteLater(delay, delegate
+		    {
+			    AppleVoiceUnity.Speak(text, 0f);
+		    });
+		return;
+	    }
+	    AppleVoiceUnity.Stop();
+	    text = string.Format("-v {0} -r {1} {2};", new object[]
+	    {
+		    Main.NarratorVoice,
+		    Main.Settings.NarratorRate,
+		    text.Replace("\"", "")
+	    });
+	    Process.Start("/usr/bin/say", text);
         }
-
-        Stop();
-
-        Process.Start("/usr/bin/say", text);
-    }
 
     public static void SpeakDialog(string text, float delay = 0f)
     {
@@ -103,7 +111,6 @@ public class AppleVoiceUnity : MonoBehaviour
 
     private static void KillAll()
     {
-        Process.Start("/usr/bin/killall", "bash -kill");
         Process.Start("/usr/bin/killall", "say -kill");
     }
 }

--- a/SpeechMod/Unity/AppleVoiceUnity.cs
+++ b/SpeechMod/Unity/AppleVoiceUnity.cs
@@ -1,4 +1,4 @@
-﻿using Kingmaker;
+using Kingmaker;
 using Kingmaker.Blueprints;
 using System;
 using System.Diagnostics;
@@ -10,19 +10,15 @@ namespace SpeechMod.Unity;
 public class AppleVoiceUnity : MonoBehaviour
 {
     private static AppleVoiceUnity m_TheVoice;
-
     private static string GenderVoice => Game.Instance?.DialogController?.CurrentSpeaker?.Gender == Gender.Female ? Main.FemaleVoice : Main.MaleVoice;
     private static int GenderRate => Game.Instance?.DialogController?.CurrentSpeaker?.Gender == Gender.Female ? Main.Settings.FemaleRate : Main.Settings.MaleRate;
-
     private static bool IsVoiceInitialized()
     {
         if (m_TheVoice != null)
             return true;
-
         Main.Logger.Critical("No voice initialized!");
         return false;
     }
-
     void Start()
     {
         if (m_TheVoice != null)
@@ -59,13 +55,11 @@ public class AppleVoiceUnity : MonoBehaviour
     {
         if (!IsVoiceInitialized())
             return;
-
         if (delay > 0f)
         {
             m_TheVoice.ExecuteLater(delay, () => SpeakDialog(text));
             return;
         }
-
         string arguments = "";
         text = new Regex("<b><color[^>]+><link([^>]+)?>([^<>]*)</link></color></b>").Replace(text, "$2");
         text = text.Replace("\\n", "  ");
@@ -88,15 +82,11 @@ public class AppleVoiceUnity : MonoBehaviour
                 arguments = $"{arguments}say -v {Main.NarratorVoice} -r {Main.Settings.NarratorRate} {argumentsPart2.Replace("\"", "")};";
             }
         }
-
         text = text.Replace("\"", "");
         if (!string.IsNullOrWhiteSpace(text) && text != "</color>")
             arguments = $"{arguments}say -v {GenderVoice} -r {GenderRate} {text};";
-
         arguments = new Regex("<[^>]+>").Replace(arguments, "");
-
         KillAll();
-
         arguments = "-c \"" + arguments + "\"";
         Process.Start("/bin/bash", arguments);
     }
@@ -111,6 +101,6 @@ public class AppleVoiceUnity : MonoBehaviour
 
     private static void KillAll()
     {
-        Process.Start("/usr/bin/killall", "say -kill");
+        Process.Start("/usr/bin/killall", "say -kill").WaitForExit();
     }
 }


### PR DESCRIPTION
Apple:
- updated to use the Narrator Voice as default Voice.
- Updated the kill command (stop) to wait for the command to exit.
   Fixes killing some dialogs when starting to play them.

Patches:
- Added a LocalizedString_Patch ([HarmonyPatch(typeof(LocalizedString), "PlayVoiceOver")])
   Playes every visible dialog or reaction in the gameworld if no VoiceOver exists.
