### PR TITLE
Fix WindowsVoice memory leak; improve compatibility with other SAPI voices

### DIFF
--- a/SpeechMod/Unity/WindowsVoiceUnity.cs
+++ b/SpeechMod/Unity/WindowsVoiceUnity.cs
@@ -18,8 +18,10 @@ public class WindowsVoiceUnity : MonoBehaviour
     [DllImport(Constants.WINDOWS_VOICE_DLL)]
     private static extern void clearSpeechQueue();
     [DllImport(Constants.WINDOWS_VOICE_DLL)]
+    [return: MarshalAs(UnmanagedType.BStr)]
     private static extern string getStatusMessage();
     [DllImport(Constants.WINDOWS_VOICE_DLL)]
+    [return: MarshalAs(UnmanagedType.BStr)]
     private static extern string getVoicesAvailable();
     [DllImport(Constants.WINDOWS_VOICE_DLL)]
     private static extern int getWordLength();
@@ -67,19 +69,6 @@ public class WindowsVoiceUnity : MonoBehaviour
         if (string.IsNullOrWhiteSpace(voicesDelim))
             return Array.Empty<string>();
         string[] voices = voicesDelim.Split(['\n'], StringSplitOptions.RemoveEmptyEntries);
-        for (int i = 0; i < voices.Length; ++i)
-        {
-            if (!voices[i].Contains('-'))
-                voices[i] = $"{voices[i]}#Unknown";
-            else
-                voices[i] = voices[i].Replace(" - ", "#");
-
-            if (!voices[i].Contains("(Natural)"))
-                continue;
-
-            voices[i] = voices[i].Replace("(Natural)", "");
-            voices[i] = voices[i].Replace("(", "Natural (");
-        }
         return voices;
     }
 

--- a/WindowsVoice/WindowsVoice.h
+++ b/WindowsVoice/WindowsVoice.h
@@ -21,8 +21,8 @@ namespace WindowsVoice {
 		DLL_API void __cdecl addToSpeechQueue(const char* text);
 		DLL_API void __cdecl clearSpeechQueue();
 		DLL_API void __cdecl destroySpeech();
-		DLL_API char* __cdecl getStatusMessage();
-		DLL_API char* __cdecl getVoicesAvailable();
+		DLL_API BSTR __cdecl getStatusMessage();
+		DLL_API BSTR __cdecl getVoicesAvailable();
 		DLL_API UINT32 __cdecl getWordLength();
 		DLL_API UINT32 __cdecl getWordPosition();
 		DLL_API UINT32 __cdecl getSpeechState();

--- a/WindowsVoice/dllmain.cpp
+++ b/WindowsVoice/dllmain.cpp
@@ -204,7 +204,7 @@ namespace WindowsVoice
 							delete[] localeNameBuf;
 							// if the voice has attribute "NaturalVoiceType", consider it "natural"
 							CSpDynamicString naturalVoiceType;
-							hr = pSpTok->GetStringValue(L"NaturalVoiceType", &naturalVoiceType);
+							hr = pAttribs->GetStringValue(L"NaturalVoiceType", &naturalVoiceType);
 							if (SUCCEEDED(hr))
 							{
 								// inserts "Natural" before '('

--- a/WindowsVoice/dllmain.cpp
+++ b/WindowsVoice/dllmain.cpp
@@ -195,16 +195,29 @@ namespace WindowsVoice
 					if (SUCCEEDED(hr))
 					{
 						// get the locale name (e.g. "English (United States)")
-						int size = GetLocaleInfoW(langid, LOCALE_SLOCALIZEDDISPLAYNAME, NULL, 0);
+						int size = GetLocaleInfoW(langid, LOCALE_SENGLISHDISPLAYNAME, NULL, 0);
 						if (size != 0)
 						{
-							wchar_t* localeName = new wchar_t[size];
-							GetLocaleInfoW(langid, LOCALE_SLOCALIZEDDISPLAYNAME, localeName, size);
+							wchar_t* localeNameBuf = new wchar_t[size];
+							GetLocaleInfoW(langid, LOCALE_SENGLISHDISPLAYNAME, localeNameBuf, size);
+							wstring localeName = localeNameBuf;
+							delete[] localeNameBuf;
+							// if the voice has attribute "NaturalVoiceType", consider it "natural"
+							CSpDynamicString naturalVoiceType;
+							hr = pSpTok->GetStringValue(L"NaturalVoiceType", &naturalVoiceType);
+							if (SUCCEEDED(hr))
+							{
+								// inserts "Natural" before '('
+								size_t pos = localeName.find(L'(');
+								if (pos != wstring::npos)
+									localeName.insert(pos, L"Natural ");
+								else
+									localeName.append(L" Natural");
+							}
 							voices += voiceName;
 							voices += L'#';
 							voices += localeName;
 							voices += L'\n';
-							delete[] localeName;
 						}
 					}
 					pSpTok.Release();


### PR DESCRIPTION
## Summary

This tries to fix the memory leak problem in WindowsVoice, and changes some of the logic so it may be compatible with more third-party SAPI5 voices.

## Memory leak

The `getVoicesAvailable` function in WindowsVoice.dll returns a buffer allocated inside the DLL without providing a way to free the memory, which can cause memory leak.

As said in [this SO answer](https://stackoverflow.com/a/65832335/20413916), you can return a [BSTR](https://learn.microsoft.com/previous-versions/windows/desktop/automat/bstr) (a COM automation type) allocated with [`SysAllocString`](https://learn.microsoft.com/windows/win32/api/oleauto/nf-oleauto-sysallocstring), then in C#, mark the function with `[return: MarshalAs(UnmanagedType.BStr)]` attribute, so that .NET runtime will know how to free this string and will do this for you automatically.

In addition, the strings returned by `SpGetDescription` should be freed with [`CoTaskMemFree`](https://learn.microsoft.com/windows/win32/api/combaseapi/nf-combaseapi-cotaskmemfree).

## Voice Name vs. Description

`SpGetDescription` returns the voice description, or "long name", for example, `Microsoft Zira Desktop - English (United States)`.

Unfortunately, this "long name" cannot be used with `<voice>` tags to select a voice by its name, because `<voice>` tags use the "short name", `Microsoft Zira Desktop`.

You can get the "short name" of a voice using the following steps:

1. Use `OpenKey` to open the `"Attributes"` subkey, which returns a `ISpDataKey` COM object.
2. Get the `"Name"` value from the subkey, using `GetStringValue`.

Note that the strings allocated by SAPI, including the strings from `SpGetDescription` or from `GetStringValue`, should be freed with `CoTaskMemFree`. To simplify this, we can use `CSpDynamicString`, which can call `CoTaskMemFree` automatically.

As not every third-party SAPI voice follows the `<Voice Name> - <Voice Locale>` pattern for its description text, the method above should be better and be compatible with more SAPI voices, without further modifying the code.

As for the missing voice locale/nationality part (e.g. "English (United States)"), we can get this with [`GetLocaleInfo`](https://learn.microsoft.com/windows/win32/api/winnls/nf-winnls-getlocaleinfow). It requires a language ID, which we can get with `SpGetLanguageFromVoiceToken`.

## Testing required

I haven't tested this because I don't own this game. While the WindowsVoice DLL can be successfully built on my system, the SpeechMod cannot, because of the lack of a proper environment.