### PR TITLE
Fix low audio quality for Windows SAPI5 voices

### DIFF
--- a/WindowsVoice/dllmain.cpp
+++ b/WindowsVoice/dllmain.cpp
@@ -26,6 +26,20 @@ namespace WindowsVoice
 			return;
 		}
 
+		ISpAudio* pAudio = nullptr;
+
+		if (SUCCEEDED(CoCreateInstance(CLSID_SpMMAudioOut, nullptr, CLSCTX_ALL, IID_ISpAudio, reinterpret_cast<void**>(&pAudio))))
+		{
+			// Force the audio format to be 48kHz 16-bit stereo
+			CSpStreamFormat format;
+			if (SUCCEEDED(format.AssignFormat(SPSF_48kHz16BitStereo)))
+			{
+				pAudio->SetFormat(format.FormatId(), format.WaveFormatExPtr());
+				pVoice->SetOutput(pAudio, FALSE);
+			}
+			pAudio->Release();
+		}
+
 		theStatusMessage = L"Speech ready.";
 		speechState = speech_state_enum::ready;
 


### PR DESCRIPTION
XML tags `<voice>` are used to change the voice, but the output audio format is affected by the current selected voice, which is the system default voice. If the system default voice only support a lower audio quality (for example, 16kHz sample rate), the entire speech audio will be output at this quality, which can make higher quality voices sound worse.

This change attempts to fix the problem by forcing the output audio format to be 48kHz 16-bit stereo, the highest quality preset in SAPI, no matter what format the voice and the audio device support. SAPI will convert the audio format when necessary.