### PR TITLE
feat: add narrator voice support for bracketed text

### DIFF
--- a/SpeechMod/Settings.cs
+++ b/SpeechMod/Settings.cs
@@ -6,6 +6,8 @@ public class Settings : UnityModManager.ModSettings
 {
     public string[] AvailableVoices;
 
+    public bool UseBracketNarratorVoice = true;
+
     public int NarratorVoice = 0;
     public int NarratorRate = 0;
     public int NarratorVolume = 100;

--- a/SpeechMod/Unity/MenuGUI.cs
+++ b/SpeechMod/Unity/MenuGUI.cs
@@ -17,6 +17,13 @@ public static class MenuGUI
         AddVoiceSelector("Narrator Voice - See nationality below", ref Main.Settings.NarratorVoice, ref m_NarratorPreviewText, ref Main.Settings.NarratorRate, ref Main.Settings.NarratorVolume, ref Main.Settings.NarratorPitch, VoiceType.Narrator);
 
         GUILayout.BeginVertical("", GUI.skin.box);
+        GUILayout.BeginHorizontal();
+        GUILayout.Label("Use Narrator voice for text in brackets [ ]", GUILayout.ExpandWidth(false));
+        Main.Settings.UseBracketNarratorVoice = GUILayout.Toggle(Main.Settings.UseBracketNarratorVoice, "Enabled");
+        GUILayout.EndHorizontal();
+        GUILayout.EndVertical();
+
+        GUILayout.BeginVertical("", GUI.skin.box);
 
         GUILayout.BeginHorizontal();
         GUILayout.Label("Use specific voice for protagonist", GUILayout.ExpandWidth(false));


### PR DESCRIPTION
### Feature: Narrator voice for [brackets]

**Goal:** Swaps to the Narrator voice for text inside brackets `[ ]` for an "audiobook" experience.

**Key Changes:**
* **Auto-Switching:** Wraps bracketed text in Narrator tags dynamically.
* **Smart Return:** Remembers the previous speaker's voice to resume correctly.
* **Toggle Option:** Added "Use Narrator voice for text in brackets [ ]" to the UMM settings.

**Tested:** Works with gendered voices and complex dialogue strings.