### PR TITLE
feat: keybind toggle for autoplay dialog

### DIFF
--- a/SpeechMod/Keybinds/ToggleAutoPlay.cs
+++ b/SpeechMod/Keybinds/ToggleAutoPlay.cs
@@ -16,7 +16,7 @@ public class ToggleAutoPlay() : ModHotkeySettingEntry(_key, _title, _tooltip, _d
     private const string _key = "autoplay.toggle";
     private const string _title = "Toggle autoplay";
     private const string _tooltip = "Toggles autoplay on and off.";
-    private const string _defaultValue = "%A;;All;false";
+    private const string _defaultValue = "%T;;All;false";
     private const string BIND_NAME = $"{Constants.SETTINGS_PREFIX}.newcontrols.ui.{_key}";
 
     public override SettingStatus TryEnable() => TryEnableAndPatch(typeof(Patches));

--- a/SpeechMod/Keybinds/ToggleAutoPlay.cs
+++ b/SpeechMod/Keybinds/ToggleAutoPlay.cs
@@ -36,11 +36,11 @@ public class ToggleAutoPlay() : ModHotkeySettingEntry(_key, _title, _tooltip, _d
             Debug.Log($"{nameof(CommonPCView)}_{nameof(CommonPCView.BindViewImplementation)}_Postfix : {BIND_NAME}");
 #endif
             var autoPlayOffText = LocalizationManager.CurrentPack!.GetText("osmodium.speechmod.feature.autoplay.toggle.notification.off", false);
-            if (string.IsNullOrWhiteSpace(autoPlayOffText))
+            if (!string.IsNullOrWhiteSpace(autoPlayOffText))
                 _ToggleAutoPlayOffText = autoPlayOffText;
 
             var autoPlayOnText = LocalizationManager.CurrentPack!.GetText("osmodium.speechmod.feature.autoplay.toggle.notification.on", false);
-            if (string.IsNullOrWhiteSpace(autoPlayOnText))
+            if (!string.IsNullOrWhiteSpace(autoPlayOnText))
                 _ToggleAutoPlayOnText = autoPlayOnText;
 
             if (Game.Instance.Keyboard.m_Bindings.Exists(binding => binding.Name.Equals(BIND_NAME)))

--- a/SpeechMod/Keybinds/ToggleAutoPlay.cs
+++ b/SpeechMod/Keybinds/ToggleAutoPlay.cs
@@ -1,0 +1,68 @@
+﻿using HarmonyLib;
+using Kingmaker;
+using Kingmaker.Localization;
+using Kingmaker.UI.MVVM._PCView.Common;
+using SpeechMod.Configuration.Settings;
+using System;
+
+#if DEBUG
+using UnityEngine;
+#endif
+
+namespace SpeechMod.Keybinds;
+
+public class ToggleAutoPlay() : ModHotkeySettingEntry(_key, _title, _tooltip, _defaultValue)
+{
+    private const string _key = "autoplay.toggle";
+    private const string _title = "Toggle autoplay";
+    private const string _tooltip = "Toggles autoplay on and off.";
+    private const string _defaultValue = "%A;;All;false";
+    private const string BIND_NAME = $"{Constants.SETTINGS_PREFIX}.newcontrols.ui.{_key}";
+
+    public override SettingStatus TryEnable() => TryEnableAndPatch(typeof(Patches));
+
+    [HarmonyPatch]
+    private static class Patches
+    {
+        private static string _ToggleAutoPlayOffText = "SpeechMod: Autoplay toggled OFF!";
+        private static string _ToggleAutoPlayOnText = "SpeechMod: Autoplay toggled ON!";
+        private static IDisposable _disposableBinding;
+
+        [HarmonyPatch(typeof(CommonPCView), nameof(CommonPCView.BindViewImplementation))]
+        [HarmonyPostfix]
+        private static void Add(CommonPCView __instance)
+        {
+#if DEBUG
+            Debug.Log($"{nameof(CommonPCView)}_{nameof(CommonPCView.BindViewImplementation)}_Postfix : {BIND_NAME}");
+#endif
+            var autoPlayOffText = LocalizationManager.CurrentPack!.GetText("osmodium.speechmod.feature.autoplay.toggle.notification.off", false);
+            if (string.IsNullOrWhiteSpace(autoPlayOffText))
+                _ToggleAutoPlayOffText = autoPlayOffText;
+
+            var autoPlayOnText = LocalizationManager.CurrentPack!.GetText("osmodium.speechmod.feature.autoplay.toggle.notification.on", false);
+            if (string.IsNullOrWhiteSpace(autoPlayOnText))
+                _ToggleAutoPlayOnText = autoPlayOnText;
+
+            if (Game.Instance.Keyboard.m_Bindings.Exists(binding => binding.Name.Equals(BIND_NAME)))
+            {
+#if DEBUG
+                Debug.Log($"Binding {BIND_NAME} already exists! Disposing of binding...");
+#endif
+                _disposableBinding.Dispose();
+            }
+
+            _disposableBinding = Game.Instance!.Keyboard!.Bind(BIND_NAME, delegate { ToggleAutoPlay(__instance); });
+            __instance?.AddDisposable(_disposableBinding);
+        }
+
+        private static void ToggleAutoPlay(CommonPCView instance)
+        {
+            Main.Settings.AutoPlay = !Main.Settings.AutoPlay;
+
+            if (instance.m_WarningsText != null && Main.Settings!.ShowNotificationOnPlaybackStop)
+            {
+                instance.m_WarningsText?.Show(Main.Settings.AutoPlay ? _ToggleAutoPlayOnText : _ToggleAutoPlayOffText);
+            }
+        }
+    }
+}

--- a/SpeechMod/Keybinds/ToggleBarks.cs
+++ b/SpeechMod/Keybinds/ToggleBarks.cs
@@ -36,11 +36,11 @@ public class ToggleBarks() : ModHotkeySettingEntry(_key, _title, _tooltip, _defa
             Debug.Log($"{nameof(CommonPCView)}_{nameof(CommonPCView.BindViewImplementation)}_Postfix : {BIND_NAME}");
 #endif
             var barksOffText = LocalizationManager.CurrentPack!.GetText("osmodium.speechmod.feature.barks.toggle.notification.off", false);
-            if (string.IsNullOrWhiteSpace(barksOffText))
+            if (!string.IsNullOrWhiteSpace(barksOffText))
                 _ToggleBarksOffText = barksOffText;
 
             var barksOnText = LocalizationManager.CurrentPack!.GetText("osmodium.speechmod.feature.barks.toggle.notification.on", false);
-            if (string.IsNullOrWhiteSpace(barksOnText))
+            if (!string.IsNullOrWhiteSpace(barksOnText))
                 _ToggleBarksOnText = barksOnText;
 
             if (Game.Instance.Keyboard.m_Bindings.Exists(binding => binding.Name.Equals(BIND_NAME)))

--- a/SpeechMod/Localization/enGB.json
+++ b/SpeechMod/Localization/enGB.json
@@ -24,11 +24,17 @@
     "osmodium.speechmod.feature.barks.toggle.notification.on": {
       "Text": "SpeechMod: Barks toggled ON!"
     },
+    "osmodium.speechmod.feature.autoplay.toggle.description": {
+      "Text": "Toggle Auto play dialog"
+    },
+    "osmodium.speechmod.feature.autoplay.toggle.tooltip-description": {
+      "Text": "Toggles Auto play dialog ON and OFF."
+    },
     "osmodium.speechmod.feature.autoplay.toggle.notification.off": {
-      "Text": "SpeechMod: Autoplay toggled OFF!"
+      "Text": "SpeechMod: Auto play dialog toggled OFF!"
     },
     "osmodium.speechmod.feature.autoplay.toggle.notification.on": {
-      "Text": "SpeechMod: Autoplay toggled ON!"
+      "Text": "SpeechMod: Auto play dialog toggled ON!"
     }
   }
 }

--- a/SpeechMod/Localization/enGB.json
+++ b/SpeechMod/Localization/enGB.json
@@ -1,28 +1,34 @@
 {
-    "Strings": {
-        "osmodium.speechmod.group.main": {
-            "Text": "Speech Mod"
-        },
-        "osmodium.speechmod.feature.playback.stop.description": {
-            "Text": "Stop playback"
-        },
-        "osmodium.speechmod.feature.playback.stop.tooltip-description": {
-            "Text": "Stops playback of SpeechMod TTS when it is playing."
-        },
-        "osmodium.speechmod.feature.playback.stop.notification": {
-            "Text": "SpeechMod: Playback stopped!"
-        },
-        "osmodium.speechmod.feature.barks.toggle.description": {
-            "Text": "Toggle barks"
-        },
-        "osmodium.speechmod.feature.barks.toggle.tooltip-description": {
-            "Text": "Toggles playback of barks ON and OFF.\nBarks are the small text boxes above characters heads when they speak."
-        },
-        "osmodium.speechmod.feature.barks.toggle.notification.off": {
-            "Text": "SpeechMod: Barks toggled OFF!"
-        },
-        "osmodium.speechmod.feature.barks.toggle.notification.on": {
-            "Text": "SpeechMod: Barks toggled ON!"
-        }
+  "Strings": {
+    "osmodium.speechmod.group.main": {
+      "Text": "Speech Mod"
+    },
+    "osmodium.speechmod.feature.playback.stop.description": {
+      "Text": "Stop playback"
+    },
+    "osmodium.speechmod.feature.playback.stop.tooltip-description": {
+      "Text": "Stops playback of SpeechMod TTS when it is playing."
+    },
+    "osmodium.speechmod.feature.playback.stop.notification": {
+      "Text": "SpeechMod: Playback stopped!"
+    },
+    "osmodium.speechmod.feature.barks.toggle.description": {
+      "Text": "Toggle barks"
+    },
+    "osmodium.speechmod.feature.barks.toggle.tooltip-description": {
+      "Text": "Toggles playback of barks ON and OFF.\nBarks are the small text boxes above characters heads when they speak."
+    },
+    "osmodium.speechmod.feature.barks.toggle.notification.off": {
+      "Text": "SpeechMod: Barks toggled OFF!"
+    },
+    "osmodium.speechmod.feature.barks.toggle.notification.on": {
+      "Text": "SpeechMod: Barks toggled ON!"
+    },
+    "osmodium.speechmod.feature.autoplay.toggle.notification.off": {
+      "Text": "SpeechMod: Autoplay toggled OFF!"
+    },
+    "osmodium.speechmod.feature.autoplay.toggle.notification.on": {
+      "Text": "SpeechMod: Autoplay toggled ON!"
     }
+  }
 }

--- a/SpeechMod/Main.cs
+++ b/SpeechMod/Main.cs
@@ -80,7 +80,7 @@ public static class Main
         if (ModConfigurationManager.Instance.GroupedSettings.TryGetValue("main", out _))
             return;
 
-        ModConfigurationManager.Instance.GroupedSettings.Add("main", [new PlaybackStop(), new ToggleBarks()]);
+        ModConfigurationManager.Instance.GroupedSettings.Add("main", [new PlaybackStop(), new ToggleBarks(), new ToggleAutoPlay()]);
     }
 
     private static bool SetAvailableVoices()


### PR DESCRIPTION
### Feature: Keybind to toggle "Auto Play Dialog"

**Goal:** Adds a dedicated hotkey to toggle the "Auto Play Dialog" setting on the fly for a smoother dialogue experience.

**Key Changes:**
* **New Hotkey:** Added `ToggleAutoPlay` hotkey support (Default: `Ctrl+T`).
* **On-Screen Feedback:** Toggling the setting now triggers a visual notification in the game's warning text UI.

**Localization Fix:**
* Corrected the validation logic in the localization fallback (`!string.IsNullOrWhiteSpace`) for the existing Barks toggle to ensure default text displays correctly if translations are missing.